### PR TITLE
Use commonjs instead

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,12 +1,12 @@
 'use strict';
 
-import { createClient } from '@supabase/supabase-js'
+const { createClient } = require('@supabase/supabase-js')
 
-export default {
+module.exports = {
   install: function (Vue, options) {
     const supabase = createClient(options.supabaseUrl, options.supabaseKey, options.supabaseOptions)
 
-    Object.defineProperties(Vue.prototype, {
+        Object.defineProperties(Vue.prototype, {
       $supabase: {
         get: function() {
           return supabase;
@@ -16,4 +16,4 @@ export default {
 
     Vue.supabase = supabase;
   }
-};
+}

--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ module.exports = {
   install: function (Vue, options) {
     const supabase = createClient(options.supabaseUrl, options.supabaseKey, options.supabaseOptions)
 
-        Object.defineProperties(Vue.prototype, {
+    Object.defineProperties(Vue.prototype, {
       $supabase: {
         get: function() {
           return supabase;


### PR DESCRIPTION
## What kind of change does this PR introduce?
Makes module compatible with commonjs syntax, fixes issue with use in nuxt modules (TBD)

## What is the current behavior?
No functional changes present, everything should work like before

## What is the new behavior?
No functional changes present, everything should work like before

## Additional context
For the issue https://github.com/supabase/nuxt-supabase/issues/1

Here's a repository where this is working https://github.com/sduduzog/nuxt-supabase-issue