### PR TITLE
Fix typescript definitions for Vite

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,4 @@
-import Vue from 'vue'
-
 import { SupabaseClient } from '@supabase/supabase-js'
-
 declare module 'vue/types/vue' {
   interface Vue {
     $supabase: SupabaseClient
@@ -16,6 +13,4 @@ declare module 'vue/types/vue' {
  */
 export function useSupabase(key?: string): SupabaseClient;
 
-export default {
-  install(Vue: typeof Vue, options: any): void
-}
+export function install(Vue: any, options?: any): void;


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix: Everything works as it should for non vite+typescript projects but the command `vue-tsc --noEmit` fails.

## What is the current behavior?
Issue discovered with type checking

## What is the new behavior?
No functional changes

## Additional context

![image](https://user-images.githubusercontent.com/48126337/127683592-82d087c3-06c0-4f9a-94ee-d9888634cd42.png)

